### PR TITLE
Disable query cache

### DIFF
--- a/lib/querygazer/query.rb
+++ b/lib/querygazer/query.rb
@@ -30,7 +30,7 @@ module Querygazer
 
     private
     def lazy_call
-      @result = Result.new(@dataset_cli.query(@sql))
+      @result = Result.new(@dataset_cli.query(@sql, cache: false))
       @successful = true
     rescue => e
       @query_error = e

--- a/lib/querygazer/version.rb
+++ b/lib/querygazer/version.rb
@@ -1,3 +1,3 @@
 module Querygazer
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
Hello @udzura san!

This pull request proposes that querygazer does not use BigQuery's cache when executing queries.

I have encountered the problem in the following case:

1. Run querygazer
2. Table state changes
3. Run querygazer again (at this time the test case expects the table state after the change)

BigQuery keeps a query cache for 24 hours ([document](https://cloud.google.com/bigquery/docs/cached-results)). If the above operation is performed within 24 hours, the cache in step 1 will be used in step 3, and the spec will fail.

Many thanks, 😃 